### PR TITLE
fix ban logic

### DIFF
--- a/lib/BruteForceProtectionConfig.php
+++ b/lib/BruteForceProtectionConfig.php
@@ -83,7 +83,7 @@ class BruteForceProtectionConfig {
 		$timeThreshold = $this->config->getAppValue(
 			'brute_force_protection',
 			'brute_force_protection_time_threshold',
-			'600'
+			'60'
 		);
 		return \intval($timeThreshold);
 	}

--- a/lib/Jobs/ExpireOldAttempts.php
+++ b/lib/Jobs/ExpireOldAttempts.php
@@ -39,8 +39,9 @@ class ExpireOldAttempts extends TimedJob {
 		$this->mapper = $mapper;
 		$this->config = $config;
 	}
+
 	public function run($argument) {
-		$threshold = $this->config->getBruteForceProtectionTimeThreshold();
+		$threshold = $this->config->getBruteForceProtectionTimeThreshold() + $this->config->getBruteForceProtectionBanPeriod();
 		$this->mapper->deleteOldFailedLoginAttempts($threshold);
 	}
 }

--- a/lib/Throttle.php
+++ b/lib/Throttle.php
@@ -94,7 +94,7 @@ class Throttle {
 	 */
 	public function applyBruteForcePolicy($uid, $ip) {
 		$banPeriod = $this->config->getBruteForceProtectionBanPeriod();
-		$banUntil = $this->attemptMapper->getLastFailedLoginAttemptTimeForIp($ip)+$banPeriod;
+		$banUntil = $this->attemptMapper->getLastFailedLoginAttemptTimeForUidIpCombination($uid, $ip) + $banPeriod;
 		if ($this->attemptMapper->getSuspiciousActivityCountForUidIpCombination($uid, $ip) >=
 			$this->config->getBruteForceProtectionFailTolerance() &&
 			$banUntil > $this->timeFactory->getTime()) {

--- a/tests/BruteForceProtectionConfigTest.php
+++ b/tests/BruteForceProtectionConfigTest.php
@@ -86,7 +86,7 @@ class BruteForceProtectionConfigTest extends TestCase {
 	 */
 	public function testGetBruteForceProtectionTimeThreshold($appConfigValue, $expected) {
 		$this->config->expects($this->once())->method('getAppValue')
-			->with('brute_force_protection', 'brute_force_protection_time_threshold', '600')
+			->with('brute_force_protection', 'brute_force_protection_time_threshold', '60')
 			->willReturn($appConfigValue);
 		$this->assertSame($expected,
 			$this->bfpConfig->getBruteForceProtectionTimeThreshold()

--- a/tests/Db/FailedLoginAttemptMapperTest.php
+++ b/tests/Db/FailedLoginAttemptMapperTest.php
@@ -54,8 +54,8 @@ class FailedLoginAttemptMapperTest extends TestCase {
 	/** @var string  */
 	private $dbTable = 'bfp_failed_logins';
 
-	/** @var string $thresholdConfigVal */
-	private $thresholdConfigVal = '60';
+	/** @var int $thresholdConfigVal */
+	private $thresholdConfigVal = 60;
 
 	public function setUp() {
 		parent::setUp();
@@ -123,21 +123,21 @@ class FailedLoginAttemptMapperTest extends TestCase {
 			->method('getTime')
 			->willReturn($functionCallTime);
 
-		$this->assertEquals(2, $this->mapper->getSuspiciousActivityCountForUidIpCombination('test1', '192.168.1.1'));
+		$this->assertEquals(3, $this->mapper->getSuspiciousActivityCountForUidIpCombination('test1', '192.168.1.1'));
 		$this->assertEquals(1, $this->mapper->getSuspiciousActivityCountForUidIpCombination('test1', '192.168.1.2'));
 		$this->assertEquals(1, $this->mapper->getSuspiciousActivityCountForUidIpCombination('test2', '192.168.1.1'));
 	}
 
-	public function testGetLastFailedLoginAttemptTimeForIp() {
+	public function testGetLastFailedLoginAttemptTimeForUidIpCombination() {
 		$lastAttemptTime = $this->baseTime+100;
 		$this->configMock->expects($this->once())
-			->method('getBruteForceProtectionTimeThreshold')
-			->willReturn('300');
+			->method('getBruteForceProtectionBanPeriod')
+			->willReturn('250');
 		$this->timeFactoryMock->expects($this->once())
 			->method('getTime')
 			->willReturn($this->baseTime+300);
 
-		$this->assertEquals($this->mapper->getLastFailedLoginAttemptTimeForIp('192.168.1.1'), $lastAttemptTime);
+		$this->assertEquals($this->mapper->getLastFailedLoginAttemptTimeForUidIpCombination('test1', '192.168.1.1'), $lastAttemptTime);
 	}
 
 	public function testDeleteSuspiciousAttemptsForUidIpCombination() {

--- a/tests/Jobs/ExpireOldAttemptsTest.php
+++ b/tests/Jobs/ExpireOldAttemptsTest.php
@@ -37,8 +37,10 @@ class ExpireOldAttemptsTest extends TestCase {
 	private $mapper;
 	/** @var BruteForceProtectionConfig | \PHPUnit_Framework_MockObject_MockObject $config */
 	private $config;
-	/** @var string $thresholdConfigVal */
-	private $thresholdConfigVal = '60';
+	/** @var int $thresholdConfigVal */
+	private $thresholdConfigVal = 60;
+	/** @var int $thresholdConfigVal */
+	private $banPeriodConfigVal = 300;
 	/** @var ExpireOldAttempts $expireAttempts */
 	private $expireAttempts;
 	public function setUp() {
@@ -56,9 +58,12 @@ class ExpireOldAttemptsTest extends TestCase {
 		$this->config->expects($this->exactly(1))
 			->method('getBruteForceProtectionTimeThreshold')
 			->willReturn($this->thresholdConfigVal);
+		$this->config->expects($this->exactly(1))
+			->method('getBruteForceProtectionBanPeriod')
+			->willReturn($this->banPeriodConfigVal);
 		$this->mapper->expects($this->exactly(1))
 			->method('deleteOldFailedLoginAttempts')
-			->with($this->thresholdConfigVal);
+			->with($this->thresholdConfigVal+$this->banPeriodConfigVal);
 		$this->expireAttempts->run($argument);
 	}
 }

--- a/tests/ThrottleTest.php
+++ b/tests/ThrottleTest.php
@@ -97,8 +97,8 @@ class ThrottleTest extends TestCase {
 	 */
 	public function testApplyBruteForcePolicy($lastAttempt, $attemptCount, $banPeriod, $failTolerance, $time) {
 		$this->attemptMapper->expects($this->once())
-			->method('getLastFailedLoginAttemptTimeForIp')
-			->with('192.168.1.1')
+			->method('getLastFailedLoginAttemptTimeForUidIpCombination')
+			->with('test', '192.168.1.1')
 			->will($this->returnValue($lastAttempt));
 		$this->attemptMapper->expects($this->once())
 			->method('getSuspiciousActivityCountForUidIpCombination')


### PR DESCRIPTION
fix for #33 
- default time threshold value changed from 600 to 60
Ban algorithm change as:
- find last failed login attempts of uid and ip combination, let the time of the attempt X
- Count failed login attempts between the interval [ (X-time threshold) , X ]
- If the count of the attempts more than tolerance, ban until X + ban period.

@individual-it , in short, it should work as you expect in the beginning.