### PR TITLE
Handle blank values when setting in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/BruteForceProtectionContext.php
+++ b/tests/acceptance/features/bootstrap/BruteForceProtectionContext.php
@@ -62,6 +62,11 @@ class BruteForceProtectionContext implements Context {
 	 */
 	public function setBruteforceprotectionSetting($setting, $value) {
 		$settingName = $this->mapSettingName($setting);
+
+		if ($value === '') {
+			$value = "''";
+		}
+
 		$occResult = SetupHelper::runOcc(
 			[
 				'config:app:set',


### PR DESCRIPTION
When setting/restoring brute-force-protection settings, handle passing empty values to ``runOcc``

Fixes "dumb" test fails, particularly when the code is restoring previous values that were empty.