### PR TITLE
clean up makefile make appstore command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ appstore:
 	mkdir -p $(appstore_package_name)
 	cp --parents -r \
 	appinfo \
-	css \
 	js \
 	l10n \
 	lib \


### PR DESCRIPTION
fix for `make appstore` command, we have no css folder in this app.