### PR TITLE
Run acceptance tests against latest stable release of core

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,19 @@ pipeline:
       matrix:
         NEED_CORE: true
 
+  install-testrunner:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - git clone -b stable10 --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+      - cp -r /var/www/owncloud/apps/brute_force_protection /var/www/owncloud/testrunner/apps/
+      - cd /var/www/owncloud/testrunner
+      - make install-composer-deps
+      - make vendor-bin-deps
+    when:
+      matrix:
+        USE_RELEASE_TARBALL: true
+
   install-app:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -32,14 +45,20 @@ pipeline:
     when:
       matrix:
         NEED_INSTALL_APP: true
-        
+
   fix-permissions:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
     - chown www-data /var/www/owncloud -R
-    - chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R
-    - chmod +x /var/www/owncloud/tests/acceptance/run.sh
+    - if [ "${USE_RELEASE_TARBALL}" = "true" ];
+      then
+      chmod 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload -R;
+      chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh;
+      else
+      chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R;
+      chmod +x /var/www/owncloud/tests/acceptance/run.sh;
+      fi
     when:
       matrix:
         NEED_SERVER: true
@@ -87,6 +106,7 @@ pipeline:
       - su-exec www-data php occ config:system:set trusted_proxies 1 --value=`ip addr show eth0 | awk '$1 == "inet" {gsub(/\\/.*$/, "", $2); print $2}'`
       - su-exec www-data php occ config:system:set trusted_proxies 2 --value=`ip addr show eth1 | awk '$1 == "inet" {gsub(/\\/.*$/, "", $2); print $2}'`
       - cd /var/www/owncloud/apps/brute_force_protection
+      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/brute_force_protection; fi
       - make test-acceptance-api
     when:
       matrix:
@@ -103,6 +123,7 @@ pipeline:
       - PLATFORM=Linux
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/brute_force_protection; fi
       - make test-acceptance-webui
     when:
       matrix:
@@ -356,3 +377,26 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
+
+    # acceptance tests against latest stable release of core
+    - PHP_VERSION: 7.1
+      OC_VERSION: 10.2.0
+      TEST_SUITE: web-acceptance
+      BEHAT_SUITE: webUIBruteForceProtection
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      USE_RELEASE_TARBALL: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: 10.2.0
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiBruteForceProtection
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      USE_RELEASE_TARBALL: true


### PR DESCRIPTION
Add drone matrices to run test against latest stable release tarball.

Related Issue https://github.com/owncloud/QA/issues/611