### PR TITLE
Remove unneeded acceptance test bootstrap.php code

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -27,8 +27,4 @@ $classLoader->addPsr4(
 	"", __DIR__ . "/../../../../../../tests/acceptance/features/bootstrap", true
 );
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
-$classLoader->addPsr4(
-	"Page\\", __DIR__ . "/../../../../../../tests/acceptance/features/lib", true
-);
-
 $classLoader->register();


### PR DESCRIPTION
The core `Page` objects from core `tests/acceptance/features/lib` are already loaded by the core `tests/acceptance/features/bootstrap/bootstrap.php` - it does not need to be done again here.

(I noticed this when converting drone in the `configreport` app which also had other differences in its `tests/acceptance/features/bootstrap/bootstrap.php` )