### PR TITLE
drone notify on failure

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -929,12 +929,6 @@ def notify():
 						'from_secret': config['rocketchat']['from_secret']
 					},
 					'channel': config['rocketchat']['channel']
-				},
-				'when': {
-					'status': [
-						'success',
-						'failure'
-					]
 				}
 			}
 		],
@@ -942,6 +936,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -929,6 +929,12 @@ def notify():
 						'from_secret': config['rocketchat']['from_secret']
 					},
 					'channel': config['rocketchat']['channel']
+				},
+				'when': {
+					'status': [
+						'success',
+						'failure'
+					]
 				}
 			}
 		],

--- a/.drone.yml
+++ b/.drone.yml
@@ -1645,15 +1645,14 @@ steps:
     channel: builds
     webhook:
       from_secret: private_rocketchat
-  when:
-    status:
-    - success
-    - failure
 
 trigger:
   ref:
   - refs/tags/**
   - refs/heads/master
+  status:
+  - success
+  - failure
 
 depends_on:
 - phpunit-php7.0-sqlite

--- a/.drone.yml
+++ b/.drone.yml
@@ -1645,6 +1645,10 @@ steps:
     channel: builds
     webhook:
       from_secret: private_rocketchat
+  when:
+    status:
+    - success
+    - failure
 
 trigger:
   ref:


### PR DESCRIPTION
Like https://github.com/owncloud/activity/pull/794

If a nightly build has failure, then nothing is being reported in rocketchat, because the pipelines stop once there is a failure. So the notify pipeline is never executed.

Adjust so that the notify pipeline will execute on both success and failure.