### PR TITLE
Set trusted_proxies in acceptance tests

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -61,8 +61,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'php occ config:system:set trusted_proxies 1 --value=`ip addr show eth0 | awk \'$1 == "inet" {gsub(/\\\/.*$/, "", $2); print $2}\'`',
-						'php occ config:system:set trusted_proxies 2 --value=`ip addr show eth1 | awk \'$1 == "inet" {gsub(/\\\/.*$/, "", $2); print $2}\'`'
+						'/var/www/owncloud/testrunner/apps/brute_force_protection/tests/acceptance/setup_trusted_proxies.sh'
 					]
 				}
 			],

--- a/.drone.yml
+++ b/.drone.yml
@@ -1455,8 +1455,7 @@ steps:
   image: owncloudci/php:7.2
   commands:
   - cd /var/www/owncloud/server
-  - php occ config:system:set trusted_proxies 1 --value=`ip addr show eth0 | awk '$1 == "inet" {gsub(/\\/.*$/, "", $2); print $2}'`
-  - php occ config:system:set trusted_proxies 2 --value=`ip addr show eth1 | awk '$1 == "inet" {gsub(/\\/.*$/, "", $2); print $2}'`
+  - /var/www/owncloud/testrunner/apps/brute_force_protection/tests/acceptance/setup_trusted_proxies.sh
 
 - name: fix-permissions
   pull: always
@@ -1571,8 +1570,7 @@ steps:
   image: owncloudci/php:7.2
   commands:
   - cd /var/www/owncloud/server
-  - php occ config:system:set trusted_proxies 1 --value=`ip addr show eth0 | awk '$1 == "inet" {gsub(/\\/.*$/, "", $2); print $2}'`
-  - php occ config:system:set trusted_proxies 2 --value=`ip addr show eth1 | awk '$1 == "inet" {gsub(/\\/.*$/, "", $2); print $2}'`
+  - /var/www/owncloud/testrunner/apps/brute_force_protection/tests/acceptance/setup_trusted_proxies.sh
 
 - name: fix-permissions
   pull: always

--- a/tests/acceptance/features/apiBruteForceProtection/bruteforceprotection.feature
+++ b/tests/acceptance/features/apiBruteForceProtection/bruteforceprotection.feature
@@ -45,7 +45,7 @@ Feature: brute force protection
       | MKCOL    | /remote.php/dav/files/user1/blocked     | 201       |
       | MKCOL    | /remote.php/webdav/blocked              | 201       |
 
-  Scenario Outline: access is still possible from as an other user after a user was blocked
+  Scenario Outline: access is still possible as another user after a user was blocked
     Given these users have been created with skeleton files:
       | username | password | displayname | email        |
       | user2    | 1234     | User Two    | u2@oc.com.np |
@@ -64,7 +64,7 @@ Feature: brute force protection
       | MKCOL    | /remote.php/dav/files/user2/blocked     | 201       |
       | MKCOL    | /remote.php/webdav/blocked              | 201       |
 
-  Scenario Outline: access is still possible from an other IP after user/ip combination was blocked
+  Scenario Outline: access is still possible from another IP after user/ip combination was blocked
     When the client accesses the server from IP address "10.4.1.248" using X-Forwarded-For header
     And user "user1" sends HTTP method "<method>" to URL "<endpoint>" with password "notvalid"
     And user "user1" sends HTTP method "<method>" to URL "<endpoint>" with password "notvalid"

--- a/tests/acceptance/setup_trusted_proxies.sh
+++ b/tests/acceptance/setup_trusted_proxies.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+ips=($(hostname -I))
+index=0
+for ip in "${ips[@]}"
+  do
+    php occ config:system:set trusted_proxies $index --value=$ip
+    ((index++))
+  done
+exit 0


### PR DESCRIPTION
Fixes issue #88 

The `ip` command is not available any more in the `owncloudci/php` docker. But `hostname`  is available. Actually that is useful - `hostname -I` outputs the IP addresses of all interfaces. We can loop around and set a `trusted_proxies` entry for each of those. (Usually there is just one when being run in the drone-docker environment.

If `setup_trusted_proxies.sh` script is useful as a "test setup helper" in core and/or other repos, then we can move it into core `tests/acceptance`. For no, we want to get CI green here!