### PR TITLE
Protect public links password page

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -45,6 +45,9 @@ config = {
 			'suites': {
 				'webUIBruteForceProtection': 'webUIBruteForce',
 			},
+			'servers': [
+				'daily-master-qa'
+			],
 			'browsers': [
 				'chrome',
 				'firefox'

--- a/appinfo/Migrations/Version20191109111104.php
+++ b/appinfo/Migrations/Version20191109111104.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+namespace OCA\brute_force_protection\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+class Version20191109111104 implements ISchemaMigration {
+
+	/** @var  string */
+	private $prefix;
+
+	public function changeSchema(Schema $schema, array $options) {
+		$this->prefix = $options['tablePrefix'];
+		if (!$schema->hasTable("{$this->prefix}bfp_link_accesses")) {
+			$table = $schema->createTable("{$this->prefix}bfp_link_accesses");
+			$table->addColumn('id', 'integer', [
+				'autoincrement' => true,
+				'unsigned' => true,
+				'notnull' => true,
+				'length' => 11,
+			]);
+			$table->addColumn('ip', 'string', [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('link_token', 'string', [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('attempted_at', 'integer', [
+				'notnull' => true,
+			]);
+
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['ip'], 'bfp_link_accesses_ip');
+			$table->addIndex(['attempted_at'], 'bfp_link_accesses_at');
+		}
+	}
+}

--- a/appinfo/Migrations/Version20191109111104.php
+++ b/appinfo/Migrations/Version20191109111104.php
@@ -26,14 +26,10 @@ use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;
 
 class Version20191109111104 implements ISchemaMigration {
-
-	/** @var  string */
-	private $prefix;
-
 	public function changeSchema(Schema $schema, array $options) {
-		$this->prefix = $options['tablePrefix'];
-		if (!$schema->hasTable("{$this->prefix}bfp_link_accesses")) {
-			$table = $schema->createTable("{$this->prefix}bfp_link_accesses");
+		$prefix = $options['tablePrefix'];
+		if (!$schema->hasTable("{$prefix}bfp_link_accesses")) {
+			$table = $schema->createTable("{$prefix}bfp_link_accesses");
 			$table->addColumn('id', 'integer', [
 				'autoincrement' => true,
 				'unsigned' => true,

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,11 +21,11 @@ See the [2-Factor Authentication](https://marketplace.owncloud.com/apps/twofacto
 	<summary>Prevent attackers from guessing user passwords</summary>
 	<licence>GPLv2</licence>
 	<author>Semih Serhat Karakaya</author>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<namespace>BruteForceProtection</namespace>
 	<use-migrations>true</use-migrations>
 	<dependencies>
-		<owncloud min-version="10.2" max-version="10" />
+		<owncloud min-version="10.5" max-version="10" />
 	</dependencies>
 	<types>
 		<prelogin/>

--- a/lib/BruteForceProtectionConfig.php
+++ b/lib/BruteForceProtectionConfig.php
@@ -75,7 +75,7 @@ class BruteForceProtectionConfig {
 	}
 
 	/**
-	 * Count failed login attempts over how many seconds
+	 * Count failed attempts over how many seconds
 	 *
 	 * @return int
 	 */

--- a/lib/Db/FailedLinkAccess.php
+++ b/lib/Db/FailedLinkAccess.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+namespace OCA\BruteForceProtection\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method int getId()
+ * @method void setId(\int $id)
+ * @method string getIp()
+ * @method void setIp(string $ip)
+ * @method string getLinkToken()
+ * @method void setLinkToken(string $linkToken)
+ * @method int getAttemptedAt()
+ * @method void setAttemptedAt(int $attemptedAt)
+ */
+class FailedLinkAccess extends Entity {
+
+	/** @var string $ip */
+	protected $ip;
+
+	/** @var string $linkToken */
+	protected $linkToken;
+
+	/** @var int $attemptedAt */
+	protected $attemptedAt;
+}

--- a/lib/Db/FailedLinkAccess.php
+++ b/lib/Db/FailedLinkAccess.php
@@ -2,7 +2,7 @@
 /**
  * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  *
- * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @copyright Copyright (c) 2020, ownCloud GmbH
  * @license GPL-2.0
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/Db/FailedLinkAccessMapper.php
+++ b/lib/Db/FailedLinkAccessMapper.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
- * @author Michael Usher <michael.usher@aarnet.edu.au>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019 ownCloud GmbH
  * @license GPL-2.0
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -30,10 +29,10 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 
 /**
- * Class FailedLoginAttemptMapper
+ * Class FailedLinkAccessMapper
  * @package OCA\BruteForceProtection\Db
  */
-class FailedLoginAttemptMapper extends Mapper {
+class FailedLinkAccessMapper extends Mapper {
 
 	/**
 	 * @var BruteForceProtectionConfig $config
@@ -48,10 +47,10 @@ class FailedLoginAttemptMapper extends Mapper {
 	/**
 	 * @var string $tableName
 	 */
-	protected $tableName = 'bfp_failed_logins';
+	protected $tableName = 'bfp_link_accesses';
 
 	/**
-	 * FailedLoginAttemptMapper constructor.
+	 * FailedLinkAccessMapper constructor.
 	 *
 	 * @param IDBConnection $db
 	 * @param BruteForceProtectionConfig $config
@@ -68,17 +67,17 @@ class FailedLoginAttemptMapper extends Mapper {
 	}
 
 	/**
-	 * @param string $uid
+	 * @param string $token
 	 * @param string $ip
 	 * @return int
 	 */
-	public function getFailedLoginCountForUidIpCombination($uid, $ip) {
+	public function getFailedAccessCountForTokenIpCombination($token, $ip) {
 		$builder = $this->db->getQueryBuilder();
-		$thresholdTime = $this->getLastFailedLoginAttemptTimeForUidIpCombination($uid, $ip) - $this->config->getBruteForceProtectionTimeThreshold();
+		$thresholdTime = $this->getLastFailedAccessTimeForTokenIpCombination($token, $ip) - $this->config->getBruteForceProtectionTimeThreshold();
 		$attempts = $builder->selectAlias($builder->createFunction('COUNT(*)'), 'count')
 			->from($this->tableName)
 			->where($builder->expr()->gt('attempted_at', $builder->createNamedParameter($thresholdTime)))
-			->andWhere($builder->expr()->eq('uid', $builder->createNamedParameter($uid)))
+			->andWhere($builder->expr()->eq('link_token', $builder->createNamedParameter($token)))
 			->andWhere($builder->expr()->eq('ip', $builder->createNamedParameter($ip)))
 			->execute()
 			->fetch();
@@ -86,33 +85,36 @@ class FailedLoginAttemptMapper extends Mapper {
 	}
 
 	/**
-	 * @param string $uid
+	 * @param string $token
 	 * @param string $ip
 	 * @return int
 	 */
-	public function getLastFailedLoginAttemptTimeForUidIpCombination($uid, $ip) {
+	public function getLastFailedAccessTimeForTokenIpCombination($token, $ip) {
 		$builder = $this->db->getQueryBuilder();
 		$thresholdTime = $this->timeFactory->getTime() - $this->config->getBruteForceProtectionBanPeriod();
 		$lastAttempt = $builder->select('attempted_at')
 			->from($this->tableName)
 			->where($builder->expr()->gt('attempted_at', $builder->createNamedParameter($thresholdTime)))
-			->andWhere($builder->expr()->eq('uid', $builder->createNamedParameter($uid)))
+			->andWhere($builder->expr()->eq('link_token', $builder->createNamedParameter($token)))
 			->andWhere($builder->expr()->eq('ip', $builder->createNamedParameter($ip)))
 			->orderBy('attempted_at', 'DESC')
 			->setMaxResults(1)
 			->execute()
 			->fetch();
-		return ($lastAttempt === false) ? 0 : \intval($lastAttempt['attempted_at']);
+		if ($lastAttempt === false) {
+			return 0;
+		}
+		return \intval($lastAttempt['attempted_at']);
 	}
 
 	/**
-	 * @param string $uid
+	 * @param string $token
 	 * @param string $ip
 	 */
-	public function deleteFailedLoginAttemptsForUidIpCombination($uid, $ip) {
+	public function deleteFailedAccessForTokenIpCombination($token, $ip) {
 		$builder = $this->db->getQueryBuilder();
 		$builder->delete($this->tableName)
-			->where($builder->expr()->eq('uid', $builder->createNamedParameter($uid)))
+			->where($builder->expr()->eq('link_token', $builder->createNamedParameter($token)))
 			->andWhere($builder->expr()->eq('ip', $builder->createNamedParameter($ip)))
 			->execute();
 	}
@@ -122,7 +124,7 @@ class FailedLoginAttemptMapper extends Mapper {
 	 *
 	 * @param int $threshold the amount of threshold seconds
 	 */
-	public function deleteOldFailedLoginAttempts($threshold) {
+	public function deleteOldFailedAccesses($threshold) {
 		$builder = $this->db->getQueryBuilder();
 		$thresholdTime = $this->timeFactory->getTime() - $threshold;
 		$builder->delete($this->tableName)

--- a/lib/Exceptions/LinkAuthException.php
+++ b/lib/Exceptions/LinkAuthException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+namespace OCA\BruteForceProtection\Exceptions;
+
+class LinkAuthException extends \Exception {
+}

--- a/lib/Exceptions/LinkAuthException.php
+++ b/lib/Exceptions/LinkAuthException.php
@@ -2,7 +2,7 @@
 /**
  * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  *
- * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @copyright Copyright (c) 2020, ownCloud GmbH
  * @license GPL-2.0
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/Jobs/ExpireOldAttempts.php
+++ b/lib/Jobs/ExpireOldAttempts.php
@@ -23,25 +23,32 @@
 namespace OCA\BruteForceProtection\Jobs;
 use OC\BackgroundJob\TimedJob;
 use OCA\BruteForceProtection\BruteForceProtectionConfig;
+use OCA\BruteForceProtection\Db\FailedLinkAccessMapper;
 use OCA\BruteForceProtection\Db\FailedLoginAttemptMapper;
 
 class ExpireOldAttempts extends TimedJob {
-	/** @var FailedLoginAttemptMapper $mapper */
-	private $mapper;
+	/** @var FailedLoginAttemptMapper $failedLoginMapper */
+	private $failedLoginMapper;
+	/** @var FailedLinkAccessMapper $linkAccessMapper */
+	private $linkAccessMapper;
 	/** @var BruteForceProtectionConfig $config */
 	private $config;
+
 	public function __construct(
-		FailedLoginAttemptMapper $mapper,
+		FailedLoginAttemptMapper $failedLoginMapper,
+		FailedLinkAccessMapper $linkAccessMapper,
 		BruteForceProtectionConfig $config
 	) {
 		// Run once a day
 		$this->setInterval(24 * 60 * 60);
-		$this->mapper = $mapper;
+		$this->failedLoginMapper = $failedLoginMapper;
+		$this->linkAccessMapper = $linkAccessMapper;
 		$this->config = $config;
 	}
 
 	public function run($argument) {
 		$threshold = $this->config->getBruteForceProtectionTimeThreshold() + $this->config->getBruteForceProtectionBanPeriod();
-		$this->mapper->deleteOldFailedLoginAttempts($threshold);
+		$this->failedLoginMapper->deleteOldFailedLoginAttempts($threshold);
+		$this->linkAccessMapper->deleteOldFailedAccesses($threshold);
 	}
 }

--- a/lib/Throttle.php
+++ b/lib/Throttle.php
@@ -25,8 +25,11 @@
 namespace OCA\BruteForceProtection;
 
 use OC\User\LoginException;
+use OCA\BruteForceProtection\Db\FailedLinkAccess;
+use OCA\BruteForceProtection\Db\FailedLinkAccessMapper;
 use OCA\BruteForceProtection\Db\FailedLoginAttempt;
 use OCA\BruteForceProtection\Db\FailedLoginAttemptMapper;
+use OCA\BruteForceProtection\Exceptions\LinkAuthException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
 
@@ -36,39 +39,37 @@ use OCP\IL10N;
  */
 class Throttle {
 
-	/**
-	 * @var FailedLoginAttemptMapper $attemptMapper
-	 */
-	protected $attemptMapper;
+	/** @var FailedLoginAttemptMapper $loginAttemptMapper */
+	protected $loginAttemptMapper;
 
-	/**
-	 * @var BruteForceProtectionConfig $config
-	 */
+	/** @var FailedLinkAccessMapper $linkAccessMapper */
+	protected $linkAccessMapper;
+
+	/** @var BruteForceProtectionConfig $config */
 	protected $config;
 
-	/**
-	 * @var IL10N $l
-	 */
+	/** @var IL10N $l */
 	protected $l;
 
-	/**
-	 * @var ITimeFactory $timeFactory
-	 */
+	/** @var ITimeFactory $timeFactory */
 	protected $timeFactory;
 
 	/**
-	 * @param FailedLoginAttemptMapper $attemptMapper
+	 * @param FailedLoginAttemptMapper $loginAttemptMapper
+	 * @param FailedLinkAccessMapper $linkAccessMapper
 	 * @param BruteForceProtectionConfig $config
 	 * @param IL10N $l
 	 * @param ITimeFactory $timeFactory
 	 */
 	public function __construct(
-		FailedLoginAttemptMapper $attemptMapper,
+		FailedLoginAttemptMapper $loginAttemptMapper,
+		FailedLinkAccessMapper $linkAccessMapper,
 		BruteForceProtectionConfig $config,
 		IL10N $l,
 		ITimeFactory $timeFactory
 	) {
-		$this->attemptMapper = $attemptMapper;
+		$this->loginAttemptMapper = $loginAttemptMapper;
+		$this->linkAccessMapper = $linkAccessMapper;
 		$this->config = $config;
 		$this->l = $l;
 		$this->timeFactory = $timeFactory;
@@ -84,7 +85,7 @@ class Throttle {
 		$attempt->setUid($uid);
 		$attempt->setIp($ip);
 		$attempt->setAttemptedAt($this->timeFactory->getTime());
-		$this->attemptMapper->insert($attempt);
+		$this->loginAttemptMapper->insert($attempt);
 	}
 
 	/**
@@ -92,10 +93,10 @@ class Throttle {
 	 * @param string $ip
 	 * @throws LoginException
 	 */
-	public function applyBruteForcePolicy($uid, $ip) {
+	public function applyBruteForcePolicyForLogin($uid, $ip) {
 		$banPeriod = $this->config->getBruteForceProtectionBanPeriod();
-		$banUntil = $this->attemptMapper->getLastFailedLoginAttemptTimeForUidIpCombination($uid, $ip) + $banPeriod;
-		if ($this->attemptMapper->getSuspiciousActivityCountForUidIpCombination($uid, $ip) >=
+		$banUntil = $this->loginAttemptMapper->getLastFailedLoginAttemptTimeForUidIpCombination($uid, $ip) + $banPeriod;
+		if ($this->loginAttemptMapper->getFailedLoginCountForUidIpCombination($uid, $ip) >=
 			$this->config->getBruteForceProtectionFailTolerance() &&
 			$banUntil > $this->timeFactory->getTime()) {
 			throw new LoginException($this->l->t("Too many failed login attempts. Try again in %s.",
@@ -109,17 +110,56 @@ class Throttle {
 	 * @param string $ip
 	 * @return void
 	 */
-	public function clearSuspiciousAttemptsForUidIpCombination($uid, $ip) {
-		$this->attemptMapper->deleteSuspiciousAttemptsForUidIpCombination($uid, $ip);
+	public function clearFailedLoginAttemptsForUidIpCombination($uid, $ip) {
+		$this->loginAttemptMapper->deleteFailedLoginAttemptsForUidIpCombination($uid, $ip);
 	}
 
 	/**
-	 * @param int $banPeriod
+	 * @param string $token
+	 * @param string $ip
+	 * @return void
+	 */
+	public function addFailedLinkAccess($token, $ip) {
+		$access = new FailedLinkAccess();
+		$access->setLinkToken($token);
+		$access->setIp($ip);
+		$access->setAttemptedAt($this->timeFactory->getTime());
+		$this->linkAccessMapper->insert($access);
+	}
+
+	/**
+	 * @param string $token
+	 * @param string $ip
+	 * @throws LinkAuthException
+	 */
+	public function applyBruteForcePolicyForLinkShare($token, $ip) {
+		$banPeriod = $this->config->getBruteForceProtectionBanPeriod();
+		$banUntil = $this->linkAccessMapper->getLastFailedAccessTimeForTokenIpCombination($token, $ip) + $banPeriod;
+		if ($this->linkAccessMapper->getFailedAccessCountForTokenIpCombination($token, $ip) >=
+			$this->config->getBruteForceProtectionFailTolerance() &&
+			$banUntil > $this->timeFactory->getTime()) {
+			throw new LinkAuthException($this->l->t("Too many failed attempts. Try again in %s.",
+				[$this->parseBanPeriodForHumans($banPeriod)])
+			);
+		}
+	}
+
+	/**
+	 * @param string $token
+	 * @param string $ip
+	 * @return void
+	 */
+	public function clearFailedLinkAccesses($token, $ip) {
+		$this->linkAccessMapper->deleteFailedAccessForTokenIpCombination($token, $ip);
+	}
+
+	/**
+	 * @param int $seconds
 	 * @return string $banPeriodForHumans
 	 */
-	private function parseBanPeriodForHumans($banPeriod) {
-		return ($banPeriod / 60 < 60)
-			? $this->l->n(' %n minute', ' %n minutes', (int)\ceil($banPeriod/60))
-			: $this->l->n(' %n hour', ' %n hours', (int)\ceil(($banPeriod/60)/60));
+	private function parseBanPeriodForHumans($seconds) {
+		return ($seconds / 60 < 60)
+			? $this->l->n(' %n minute', ' %n minutes', (int)\ceil($seconds/60))
+			: $this->l->n(' %n hour', ' %n hours', (int)\ceil(($seconds/60)/60));
 	}
 }

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -30,9 +30,9 @@ script('brute_force_protection', 'settings-admin');
 	<h2 class="inlineblock"><?php p($l->t('Brute Force Protection')); ?></h2>
 	<span id="save-bfp-settings-message" class="msg"></span>
 	<div>
-		<label for="bfp-threshold-time"><?php p($l->t('Count failed login attempts over how many seconds?')) ?></label><br>
+		<label for="bfp-threshold-time"><?php p($l->t('Count failed attempts over how many seconds?')) ?></label><br>
 		<input type="number" id="bfp-threshold-time"  value="<?php p($_['bruteForceProtectionTimeThreshold']) ?>"><br>
-		<label for="bfp-fail-tolerance"><?php p($l->t('Ban after how many failed login attempts?')) ?></label><br>
+		<label for="bfp-fail-tolerance"><?php p($l->t('Ban after how many failed attempts?')) ?></label><br>
 		<input type="number" id="bfp-fail-tolerance"  value="<?php p($_['bruteForceProtectionFailTolerance']) ?>"><br>
 		<label for="bfp-ban-period"><?php p($l->t('Ban for how many seconds?')) ?></label><br>
 		<input type="number" id="bfp-ban-period" value="<?php p($_['bruteForceProtectionBanPeriod']) ?>"><br>

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -25,6 +25,8 @@ default:
         - BruteForceProtectionContext:
         - IpContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - PublicWebDavContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/apiBruteForceProtection/bruteforceprotection.feature
+++ b/tests/acceptance/features/apiBruteForceProtection/bruteforceprotection.feature
@@ -87,3 +87,30 @@ Feature: brute force protection
     And user "Alice" sends HTTP method "GET" to URL "/remote.php/webdav/welcome.txt" with password "notvalid"
     And user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "403"
+
+  @issue-112
+  Scenario: access to public link is not blocked after too many invalid requests
+    Given user "Alice" has uploaded file with content "user1 file" to "/PARENT/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | PARENT   |
+      | password    | %public% |
+    Then the public download of the last publicly shared file using the new public WebDAV API with password "abcdef" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "123abc" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "abc123" should fail with HTTP status code "500"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "%public%" should fail with HTTP status code "500"
+    #And the public download of the last publicly shared file using the new public WebDAV API with password "abc123" should fail with HTTP status code "401"
+    #And the public download of the last publicly shared file using the new public WebDAV API with password "%public%" should fail with HTTP status code "401"
+
+  @issue-112
+  Scenario: access to public link is blocked after too many invalid requests
+    Given user "Alice" has uploaded file with content "user1 file" to "/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | randomfile.txt |
+      | password    | %public%       |
+    Then the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "abcdef" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "123abc" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "abc123" should fail with HTTP status code "500"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "%public%" should fail with HTTP status code "500"
+    #And the public download of the last publicly shared file using the new public WebDAV API with password "abc123" should fail with HTTP status code "401"
+    #And the public download of the last publicly shared file using the new public WebDAV API with password "%public%" should fail with HTTP status code "401"

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -39,10 +39,8 @@ class SettingsControllerTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
-		$this->config = $this->getMockBuilder(BruteForceProtectionConfig::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->request = $this->createMock(IRequest::class);
+		$this->config = $this->createMock(BruteForceProtectionConfig::class);
 		$this->controller = new SettingsController('brute_force_protection', $this->request, $this->config);
 	}
 

--- a/tests/unit/Db/FailedLinkAccessMapperTest.php
+++ b/tests/unit/Db/FailedLinkAccessMapperTest.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
- * @author Michael Usher <michael.usher@aarnet.edu.au>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license GPL-2.0
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -25,35 +24,34 @@
 namespace OCA\BruteForceProtection\Tests\Db;
 
 use OCA\BruteForceProtection\BruteForceProtectionConfig;
-use OCA\BruteForceProtection\Db\FailedLoginAttempt;
-use OCA\BruteForceProtection\Db\FailedLoginAttemptMapper;
+use OCA\BruteForceProtection\Db\FailedLinkAccess;
+use OCA\BruteForceProtection\Db\FailedLinkAccessMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
-use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
  * @group DB
  */
-class FailedLoginAttemptMapperTest extends TestCase {
+class FailedLinkAccessMapperTest extends TestCase {
 
-	/** @var  FailedLoginAttemptMapper $mapper*/
+	/** @var  FailedLinkAccess $mapper*/
 	private $mapper;
 
 	/** @var  IDBConnection $connection*/
 	private $connection;
 
-	/** @var BruteForceProtectionConfig | MockObject $configMock */
+	/** @var BruteForceProtectionConfig | \PHPUnit\Framework\MockObject\MockObject $configMock */
 	private $configMock;
 
-	/** @var ITimeFactory | MockObject $timeFactory */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 	private $timeFactoryMock;
 
 	/** @var int $baseTime */
 	private $baseTime;
 
 	/** @var string  */
-	private $dbTable = 'bfp_failed_logins';
+	private $dbTable = 'bfp_link_accesses';
 
 	/** @var int $thresholdConfigVal */
 	private $thresholdConfigVal = 60;
@@ -64,45 +62,45 @@ class FailedLoginAttemptMapperTest extends TestCase {
 		$this->timeFactoryMock = $this->createMock(ITimeFactory::class);
 		$this->configMock = $this->createMock(BruteForceProtectionConfig::class);
 		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->mapper = new FailedLoginAttemptMapper($this->connection, $this->configMock, $this->timeFactoryMock);
+		$this->mapper = new FailedLinkAccessMapper($this->connection, $this->configMock, $this->timeFactoryMock);
 
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
-		$this->assertEmpty($result, 'we need to start with a empty bfp_failed_logins table');
+		$this->assertEmpty($result, 'we need to start with a empty bfp_link_accesses table');
 
 		$this->addInitialTestEntries();
 	}
 
 	public function addInitialTestEntries() {
-		$failedLoginAttempt = new FailedLoginAttempt();
-		$failedLoginAttempt->setUid('test1');
-		$failedLoginAttempt->setIp("192.168.1.1");
-		$failedLoginAttempt->setAttemptedAt($this->baseTime+20);
-		$this->mapper->insert($failedLoginAttempt);
+		$linkAccess = new FailedLinkAccess();
+		$linkAccess->setLinkToken('token1');
+		$linkAccess->setIp("192.168.1.1");
+		$linkAccess->setAttemptedAt($this->baseTime+20);
+		$this->mapper->insert($linkAccess);
 
-		$failedLoginAttempt = new FailedLoginAttempt();
-		$failedLoginAttempt->setUid('test1');
-		$failedLoginAttempt->setIp("192.168.1.1");
-		$failedLoginAttempt->setAttemptedAt($this->baseTime+60);
-		$this->mapper->insert($failedLoginAttempt);
+		$linkAccess = new FailedLinkAccess();
+		$linkAccess->setLinkToken('token1');
+		$linkAccess->setIp("192.168.1.1");
+		$linkAccess->setAttemptedAt($this->baseTime+60);
+		$this->mapper->insert($linkAccess);
 
-		$failedLoginAttempt = new FailedLoginAttempt();
-		$failedLoginAttempt->setUid('test1');
-		$failedLoginAttempt->setIp("192.168.1.2");
-		$failedLoginAttempt->setAttemptedAt($this->baseTime+60);
-		$this->mapper->insert($failedLoginAttempt);
+		$linkAccess = new FailedLinkAccess();
+		$linkAccess->setLinkToken('token1');
+		$linkAccess->setIp("192.168.1.2");
+		$linkAccess->setAttemptedAt($this->baseTime+60);
+		$this->mapper->insert($linkAccess);
 
-		$failedLoginAttempt = new FailedLoginAttempt();
-		$failedLoginAttempt->setUid('test2');
-		$failedLoginAttempt->setIp("192.168.1.1");
-		$failedLoginAttempt->setAttemptedAt($this->baseTime+60);
-		$this->mapper->insert($failedLoginAttempt);
+		$linkAccess = new FailedLinkAccess();
+		$linkAccess->setLinkToken('token2');
+		$linkAccess->setIp("192.168.1.1");
+		$linkAccess->setAttemptedAt($this->baseTime+60);
+		$this->mapper->insert($linkAccess);
 
-		$failedLoginAttempt = new FailedLoginAttempt();
-		$failedLoginAttempt->setUid('test1');
-		$failedLoginAttempt->setIp("192.168.1.1");
-		$failedLoginAttempt->setAttemptedAt($this->baseTime+100);
-		$this->mapper->insert($failedLoginAttempt);
+		$linkAccess = new FailedLinkAccess();
+		$linkAccess->setLinkToken('token1');
+		$linkAccess->setIp("192.168.1.1");
+		$linkAccess->setAttemptedAt($this->baseTime+100);
+		$this->mapper->insert($linkAccess);
 	}
 
 	public function tearDown(): void {
@@ -111,7 +109,7 @@ class FailedLoginAttemptMapperTest extends TestCase {
 		$query->execute();
 	}
 
-	public function testGetSuspiciousActivityCountForUidIpCombination() {
+	public function testGetFailedAccessCountForTokenIpCombination() {
 		$functionCallTime = $this->baseTime+110;
 		$this->configMock->expects($this->exactly(3))
 			->method('getBruteForceProtectionTimeThreshold')
@@ -120,12 +118,12 @@ class FailedLoginAttemptMapperTest extends TestCase {
 			->method('getTime')
 			->willReturn($functionCallTime);
 
-		$this->assertEquals(3, $this->mapper->getFailedLoginCountForUidIpCombination('test1', '192.168.1.1'));
-		$this->assertEquals(1, $this->mapper->getFailedLoginCountForUidIpCombination('test1', '192.168.1.2'));
-		$this->assertEquals(1, $this->mapper->getFailedLoginCountForUidIpCombination('test2', '192.168.1.1'));
+		$this->assertEquals(3, $this->mapper->getFailedAccessCountForTokenIpCombination('token1', '192.168.1.1'));
+		$this->assertEquals(1, $this->mapper->getFailedAccessCountForTokenIpCombination('token1', '192.168.1.2'));
+		$this->assertEquals(1, $this->mapper->getFailedAccessCountForTokenIpCombination('token2', '192.168.1.1'));
 	}
 
-	public function testGetLastFailedLoginAttemptTimeForUidIpCombination() {
+	public function testGetLastFailedAccessTimeForTokenIpCombination() {
 		$lastAttemptTime = $this->baseTime+100;
 		$this->configMock->expects($this->once())
 			->method('getBruteForceProtectionBanPeriod')
@@ -134,23 +132,23 @@ class FailedLoginAttemptMapperTest extends TestCase {
 			->method('getTime')
 			->willReturn($this->baseTime+300);
 
-		$this->assertEquals($this->mapper->getLastFailedLoginAttemptTimeForUidIpCombination('test1', '192.168.1.1'), $lastAttemptTime);
+		$this->assertEquals($this->mapper->getLastFailedAccessTimeForTokenIpCombination('token1', '192.168.1.1'), $lastAttemptTime);
 	}
 
-	public function testDeleteFailedLoginAttemptsForUidIpCombination() {
+	public function testDeleteFailedAccessForTokenIpCombination() {
 		$builder = $this->connection->getQueryBuilder();
 
 		$query = $builder->select('*')->from($this->dbTable)
 			->Where($builder->expr()->eq('ip', $builder->createNamedParameter("192.168.1.1")))
-			->andWhere($builder->expr()->eq('uid', $builder->createNamedParameter("test1")));
+			->andWhere($builder->expr()->eq('link_token', $builder->createNamedParameter("token1")));
 		$result = $query->execute()->fetchAll();
 		$this->assertCount(3, $result);
 
-		$this->mapper->deleteFailedLoginAttemptsForUidIpCombination('test1', "192.168.1.1");
+		$this->mapper->deleteFailedAccessForTokenIpCombination('token1', "192.168.1.1");
 
 		$query = $builder->select('*')->from($this->dbTable)
 			->Where($builder->expr()->eq('ip', $builder->createNamedParameter("192.168.1.1")))
-			->andWhere($builder->expr()->eq('uid', $builder->createNamedParameter("test1")));
+			->andWhere($builder->expr()->eq('link_token', $builder->createNamedParameter("token1")));
 		$result = $query->execute()->fetchAll();
 		$this->assertCount(0, $result);
 	}
@@ -164,7 +162,7 @@ class FailedLoginAttemptMapperTest extends TestCase {
 		$query = $builder->select('*')->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		$this->assertCount(5, $result);
-		$this->mapper->deleteOldFailedLoginAttempts($this->thresholdConfigVal);
+		$this->mapper->deleteOldFailedAccesses($this->thresholdConfigVal);
 		$query = $builder->select('*')->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		$this->assertCount(1, $result);

--- a/tests/unit/ThrottleTest.php
+++ b/tests/unit/ThrottleTest.php
@@ -24,52 +24,47 @@
 
 namespace OCA\BruteForceProtection\Tests;
 
+use OCA\BruteForceProtection\Db\FailedLinkAccessMapper;
 use OCA\BruteForceProtection\Db\FailedLoginAttemptMapper;
 use OCA\BruteForceProtection\Throttle;
 use OCA\BruteForceProtection\BruteForceProtectionConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ThrottleTest extends TestCase {
 
 	/** @var Throttle */
 	private $throttle;
-	/**
-	 * @var \PHPUnit\Framework\MockObject\MockObject | FailedLoginAttemptMapper
-	 */
-	private $attemptMapper;
-	/**
-	 * @var \PHPUnit\Framework\MockObject\MockObject | BruteForceProtectionConfig
-	 */
+
+	/** @var MockObject | FailedLoginAttemptMapper */
+	private $loginAttemptMapper;
+
+	/** @var MockObject | FailedLinkAccessMapper */
+	private $linkAccessMapper;
+
+	/** @var MockObject | BruteForceProtectionConfig */
 	private $configMock;
-	/**
-	 * @var \PHPUnit\Framework\MockObject\MockObject | IL10N
-	 */
+
+	/** @var MockObject | IL10N */
 	private $lMock;
-	/**
-	 * @var \PHPUnit\Framework\MockObject\MockObject | ITimeFactory
-	 */
+
+	/** @var MockObject | ITimeFactory */
 	private $timeFactoryMock;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->attemptMapper = $this->getMockBuilder(FailedLoginAttemptMapper::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->lMock = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->timeFactoryMock = $this->getMockBuilder(ITimeFactory::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->configMock = $this->getMockBuilder(BruteForceProtectionConfig::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->loginAttemptMapper = $this->createMock(FailedLoginAttemptMapper::class);
+		$this->linkAccessMapper = $this->createMock(FailedLinkAccessMapper::class);
+		$this->lMock = $this->createMock(IL10N::class);
+		$this->timeFactoryMock = $this->createMock(ITimeFactory::class);
+		$this->configMock = $this->createMock(BruteForceProtectionConfig::class);
 
 		$this->throttle = new Throttle(
-			$this->attemptMapper,
+			$this->loginAttemptMapper,
+			$this->linkAccessMapper,
 			$this->configMock,
 			$this->lMock,
 			$this->timeFactoryMock
@@ -77,13 +72,13 @@ class ThrottleTest extends TestCase {
 	}
 
 	public function testAddFailedLoginAttempt() {
-		$this->attemptMapper->expects($this->once())->method('insert');
+		$this->loginAttemptMapper->expects($this->once())->method('insert');
 
 		$this->throttle->addFailedLoginAttempt('test', '192.168.1.1');
 	}
 
 	/**
-	 * @dataProvider bruteForceTestData
+	 * @dataProvider bruteForceForLoginTestData
 	 * @param int $lastAttempt
 	 * @param int $attemptCount
 	 * @param int $banPeriod
@@ -93,12 +88,12 @@ class ThrottleTest extends TestCase {
 	public function testApplyBruteForcePolicy($lastAttempt, $attemptCount, $banPeriod, $failTolerance, $time) {
 		$this->expectException(\OC\User\LoginException::class);
 
-		$this->attemptMapper->expects($this->once())
+		$this->loginAttemptMapper->expects($this->once())
 			->method('getLastFailedLoginAttemptTimeForUidIpCombination')
 			->with('test', '192.168.1.1')
 			->will($this->returnValue($lastAttempt));
-		$this->attemptMapper->expects($this->once())
-			->method('getSuspiciousActivityCountForUidIpCombination')
+		$this->loginAttemptMapper->expects($this->once())
+			->method('getFailedLoginCountForUidIpCombination')
 			->with('test', '192.168.1.1')
 			->will($this->returnValue($attemptCount));
 		$this->configMock->expects($this->once())
@@ -110,12 +105,66 @@ class ThrottleTest extends TestCase {
 		$this->timeFactoryMock->expects($this->once())
 			->method('getTime')
 			->will($this->returnValue($time));
-		$this->throttle->applyBruteForcePolicy('test', '192.168.1.1');
+		$this->throttle->applyBruteForcePolicyForLogin('test', '192.168.1.1');
 	}
-	public function bruteForceTestData() {
+	public function bruteForceForLoginTestData() {
 		return [
 			[5, 5, 10, 4, 14],
 			[0, 3, 300, 2, 250]
 		];
+	}
+
+	public function testClearFailedLoginAttemptsForUidIpCombination() {
+		$this->loginAttemptMapper->expects($this->once())->method('deleteFailedLoginAttemptsForUidIpCombination');
+
+		$this->throttle->clearFailedLoginAttemptsForUidIpCombination('test', '192.168.1.1');
+	}
+
+	public function testAddFailedLinkAccess() {
+		$this->linkAccessMapper->expects($this->once())->method('insert');
+
+		$this->throttle->addFailedLinkAccess('test', '192.168.1.1');
+	}
+
+	/**
+	 * @dataProvider bruteForceForLoginTestData
+	 * @param int $lastAttempt
+	 * @param int $attemptCount
+	 * @param int $banPeriod
+	 * @param int $failTolerance
+	 * @param int $time
+	 */
+	public function testApplyBruteForcePolicyForLinkShare($lastAttempt, $attemptCount, $banPeriod, $failTolerance, $time) {
+		$this->expectException(\OCA\BruteForceProtection\Exceptions\LinkAuthException::class);
+
+		$this->linkAccessMapper->expects($this->once())
+			->method('getLastFailedAccessTimeForTokenIpCombination')
+			->with('test', '192.168.1.1')
+			->will($this->returnValue($lastAttempt));
+		$this->linkAccessMapper->expects($this->once())
+			->method('getFailedAccessCountForTokenIpCombination')
+			->with('test', '192.168.1.1')
+			->will($this->returnValue($attemptCount));
+		$this->configMock->expects($this->once())
+			->method('getBruteForceProtectionBanPeriod')
+			->will($this->returnValue($banPeriod));
+		$this->configMock->expects($this->once())
+			->method('getBruteForceProtectionFailTolerance')
+			->will($this->returnValue($failTolerance));
+		$this->timeFactoryMock->expects($this->once())
+			->method('getTime')
+			->will($this->returnValue($time));
+		$this->throttle->applyBruteForcePolicyForLinkShare('test', '192.168.1.1');
+	}
+	public function bruteForceLinkShareTestData() {
+		return [
+			[5, 5, 10, 4, 14],
+			[0, 3, 300, 2, 250]
+		];
+	}
+
+	public function testClearFailedLinkAccesses() {
+		$this->linkAccessMapper->expects($this->once())->method('deleteFailedAccessForTokenIpCombination');
+		$this->throttle->clearFailedLinkAccesses('test', '192.168.1.1');
 	}
 }

--- a/tests/unit/ThrottleTest.php
+++ b/tests/unit/ThrottleTest.php
@@ -71,12 +71,6 @@ class ThrottleTest extends TestCase {
 		);
 	}
 
-	public function testAddFailedLoginAttempt() {
-		$this->loginAttemptMapper->expects($this->once())->method('insert');
-
-		$this->throttle->addFailedLoginAttempt('test', '192.168.1.1');
-	}
-
 	/**
 	 * @dataProvider bruteForceForLoginTestData
 	 * @param int $lastAttempt
@@ -114,18 +108,6 @@ class ThrottleTest extends TestCase {
 		];
 	}
 
-	public function testClearFailedLoginAttemptsForUidIpCombination() {
-		$this->loginAttemptMapper->expects($this->once())->method('deleteFailedLoginAttemptsForUidIpCombination');
-
-		$this->throttle->clearFailedLoginAttemptsForUidIpCombination('test', '192.168.1.1');
-	}
-
-	public function testAddFailedLinkAccess() {
-		$this->linkAccessMapper->expects($this->once())->method('insert');
-
-		$this->throttle->addFailedLinkAccess('test', '192.168.1.1');
-	}
-
 	/**
 	 * @dataProvider bruteForceForLoginTestData
 	 * @param int $lastAttempt
@@ -161,10 +143,5 @@ class ThrottleTest extends TestCase {
 			[5, 5, 10, 4, 14],
 			[0, 3, 300, 2, 250]
 		];
-	}
-
-	public function testClearFailedLinkAccesses() {
-		$this->linkAccessMapper->expects($this->once())->method('deleteFailedAccessForTokenIpCombination');
-		$this->throttle->clearFailedLinkAccesses('test', '192.168.1.1');
 	}
 }


### PR DESCRIPTION
Fixes #57 

- Legacy OC\User hooks changed with EventDispatcher events
- Brute force protection added for public link share authentications.
- Brute force protection settings now common for login and public link share auth.
