### PR TITLE
wait for apache server to be up

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -851,6 +851,7 @@ def acceptance():
 										environment['S3_TYPE'] = 'ceph'
 									if (params['scalityS3'] != False):
 										environment['S3_TYPE'] = 'scality'
+								federationDbSuffix = '-federated'
 
 								result = {
 									'kind': 'pipeline',
@@ -863,32 +864,7 @@ def acceptance():
 									'steps':
 										installCore(server, db, params['useBundledApp']) +
 										installTestrunner(phpVersion, params['useBundledApp']) +
-									([
-										{
-											'name': 'install-federation',
-											'image': 'owncloudci/core',
-											'pull': 'always',
-											'settings': {
-												'version': server,
-												'core_path': '/var/www/owncloud/federated'
-											}
-										},
-										{
-											'name': 'configure-federation',
-											'image': 'owncloudci/php:%s' % phpVersion,
-											'pull': 'always',
-											'commands': [
-												'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
-												'cd /var/www/owncloud/federated',
-												'php occ a:l',
-												'php occ a:e testing',
-												'php occ a:l',
-												'php occ config:system:set trusted_domains 1 --value=federated',
-												'php occ log:manage --level %s' % params['logLevel'],
-												'php occ config:list'
-											]
-										}
-									] + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
+										(installFederated(server, phpVersion, params['logLevel'], db, federationDbSuffix) + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
 										installApp(phpVersion) +
 										installExtraApps(phpVersion, params['extraApps']) +
 										setupServerAndApp(phpVersion, params['logLevel']) +
@@ -919,7 +895,10 @@ def acceptance():
 										scalityService(params['scalityS3']) +
 										params['extraServices'] +
 										owncloudService(server, phpVersion, 'server', '/var/www/owncloud/server', False) +
-										(owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) if params['federatedServerNeeded'] else []),
+										((
+											owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) +
+											databaseServiceForFederation(db, federationDbSuffix)
+										) if params['federatedServerNeeded'] else [] ),
 									'depends_on': [],
 									'trigger': {}
 								}
@@ -1339,9 +1318,11 @@ def fixPermissions(phpVersion, federatedServerNeeded):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'chown -R www-data /var/www/owncloud/server'
+			'chown -R www-data /var/www/owncloud/server',
+			'wait-for-it -t 600 server:80'
 		] + ([
-			'chown -R www-data /var/www/owncloud/federated'
+			'chown -R www-data /var/www/owncloud/federated',
+			'wait-for-it -t 600 federated:80'
 		] if federatedServerNeeded else [])
 	}]
 
@@ -1360,3 +1341,68 @@ def dependsOn(earlierStages, nextStages):
 	for earlierStage in earlierStages:
 		for nextStage in nextStages:
 			nextStage['depends_on'].append(earlierStage['name'])
+
+def installFederated(federatedServerVersion, phpVersion, logLevel, db, dbSuffix = '-federated'):
+	host = getDbName(db)
+	dbType = host
+
+	username = getDbUsername(db)
+	password = getDbPassword(db)
+	database = getDbDatabase(db) + dbSuffix
+
+	if host == 'mariadb':
+		dbType = 'mysql'
+	elif host == 'postgres':
+		dbType = 'pgsql'
+	elif host == 'oracle':
+		dbType = 'oci'
+	return [
+		{
+			'name': 'install-federated',
+			'image': 'owncloudci/core',
+			'pull': 'always',
+			'settings': {
+				'version': federatedServerVersion,
+				'core_path': '/var/www/owncloud/federated',
+				'db_type': 'mysql',
+				'db_name': database,
+				'db_host': host + dbSuffix,
+				'db_username': username,
+				'db_password': password
+			},
+		},
+		{
+			'name': 'configure-federation',
+			'image': 'owncloudci/php:%s' % phpVersion,
+			'pull': 'always',
+			'commands': [
+				'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
+				'cd /var/www/owncloud/federated',
+				'php occ a:l',
+				'php occ a:e testing',
+				'php occ a:l',
+				'php occ config:system:set trusted_domains 1 --value=federated',
+				'php occ log:manage --level %s' % logLevel,
+				'php occ config:list'
+			]
+		}
+	]
+
+def databaseServiceForFederation(db, suffix):
+	dbName = getDbName(db)
+
+	if dbName not in ['mariadb', 'mysql']:
+		print('Not implemented federated database for ', dbName)
+		return []
+
+	return [{
+		'name': dbName + suffix,
+		'image': db,
+		'pull': 'always',
+		'environment': {
+			'MYSQL_USER': getDbUsername(db),
+			'MYSQL_PASSWORD': getDbPassword(db),
+			'MYSQL_DATABASE': getDbDatabase(db) + suffix,
+			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
+		}
+	}]

--- a/.drone.yml
+++ b/.drone.yml
@@ -819,6 +819,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
 
 - name: acceptance-tests
   pull: always
@@ -934,6 +935,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
 
 - name: acceptance-tests
   pull: always
@@ -1050,6 +1052,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
 
 - name: acceptance-tests
   pull: always
@@ -1165,6 +1168,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
 
 - name: acceptance-tests
   pull: always
@@ -1288,6 +1292,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
 
 - name: acceptance-tests
   pull: always
@@ -1400,6 +1405,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
 
 - name: acceptance-tests
   pull: always


### PR DESCRIPTION
apply drone starlark code from https://github.com/owncloud/activity/pull/828

- recent changes for running federated server on "real" databases
- wait for apache server to be up before starting acceptance tests

There have been some fails in `brute_force_protection` recently - issue #98 - so this PR gets the starlark code up-to-date before we try fixing that issue.