### PR TITLE
Use X-FORWADED-FOR header in Apache server

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1114,12 +1114,15 @@ def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncl
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'environment': environment,
-		'command': [
-			'/usr/local/bin/apachectl',
-			'-e',
-			'debug',
-			'-D',
-			'FOREGROUND'
+		'commands': [
+			'a2enmod remoteip',
+			'cd /etc/apache2',
+			'echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf',
+			# This replaces the first occurrence of "%h with "%a in apache2.conf file telling Apache to log the client
+			# IP as recorded by mod_remoteip (%a) rather than hostname (%h). For more info check this out:
+			# https://www.digitalocean.com/community/questions/get-client-public-ip-on-apache-server-used-behind-load-balancer
+			'sed -i \'0,/"%h/s//"%a/\' apache2.conf',
+			'/usr/local/bin/apachectl -e debug -D FOREGROUND',
 		]
 	}]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -855,12 +855,12 @@ services:
 - name: server
   pull: always
   image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
+  commands:
+  - a2enmod remoteip
+  - cd /etc/apache2
+  - echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf
+  - sed -i '0,/"%h/s//"%a/' apache2.conf
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/server
 
@@ -972,12 +972,12 @@ services:
 - name: server
   pull: always
   image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
+  commands:
+  - a2enmod remoteip
+  - cd /etc/apache2
+  - echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf
+  - sed -i '0,/"%h/s//"%a/' apache2.conf
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/server
 
@@ -1088,12 +1088,12 @@ services:
 - name: server
   pull: always
   image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
+  commands:
+  - a2enmod remoteip
+  - cd /etc/apache2
+  - echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf
+  - sed -i '0,/"%h/s//"%a/' apache2.conf
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/server
 
@@ -1205,12 +1205,12 @@ services:
 - name: server
   pull: always
   image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
+  commands:
+  - a2enmod remoteip
+  - cd /etc/apache2
+  - echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf
+  - sed -i '0,/"%h/s//"%a/' apache2.conf
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/server
 
@@ -1318,12 +1318,12 @@ services:
 - name: server
   pull: always
   image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
+  commands:
+  - a2enmod remoteip
+  - cd /etc/apache2
+  - echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf
+  - sed -i '0,/"%h/s//"%a/' apache2.conf
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/server
 
@@ -1431,12 +1431,12 @@ services:
 - name: server
   pull: always
   image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
+  commands:
+  - a2enmod remoteip
+  - cd /etc/apache2
+  - echo "RemoteIPHeader X-Forwarded-For" >> apache2.conf
+  - sed -i '0,/"%h/s//"%a/' apache2.conf
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/server
 


### PR DESCRIPTION
### Description
This PR adds `X-FORWADED-HEADER` to be used in the apache server. The `X-Forwarded-For (XFF)`header is a de-facto standard header for identifying the originating IP address of a client connecting to a web server through an HTTP proxy or a load balancer.
### Related Issues
https://github.com/owncloud/brute_force_protection/issues/98

Draft PR: https://github.com/owncloud/brute_force_protection/pull/103 asserts that the modifications made in this PR fixes issue https://github.com/owncloud/brute_force_protection/issues/98