### PR TITLE
Adjust phpstan.neon for phpstan 0.12.26 onwards

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 parameters:
   inferPrivatePropertyTypeFromConstructor: true
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
-  excludes_analyse:
-    - %currentWorkingDirectory%/appinfo/Migrations/*.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
 


### PR DESCRIPTION
- `bootstrapFiles` section
- remove the `excludes_analyse` section, the `appinfo/Migrations` code gets analyzed OK now