### PR TITLE
LinkAuthException should inherit from LoginException for proper catching on core

### DIFF
--- a/lib/Exceptions/LinkAuthException.php
+++ b/lib/Exceptions/LinkAuthException.php
@@ -23,5 +23,7 @@
 
 namespace OCA\BruteForceProtection\Exceptions;
 
-class LinkAuthException extends \Exception {
+use OC\User\LoginException;
+
+class LinkAuthException extends LoginException {
 }


### PR DESCRIPTION
To be able to show error message and return correct return response, `LinkAuthException` should inherit from `LoginException`
- Fixes #134 