### PR TITLE
Suppress PhanDeprecatedFunction for doctrine/dbal changes

### DIFF
--- a/lib/Db/FailedLinkAccessMapper.php
+++ b/lib/Db/FailedLinkAccessMapper.php
@@ -65,6 +65,7 @@ class FailedLinkAccessMapper extends Mapper {
 	 */
 	public function getFailedAccessCountForTokenIpCombination($token, $ip, $thresholdTime) {
 		$builder = $this->db->getQueryBuilder();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$attempts = $builder->selectAlias($builder->createFunction('COUNT(*)'), 'count')
 			->from($this->tableName)
 			->where($builder->expr()->gt('attempted_at', $builder->createNamedParameter($thresholdTime)))
@@ -82,6 +83,7 @@ class FailedLinkAccessMapper extends Mapper {
 	 */
 	public function getLastFailedAccessTimeForTokenIpCombination($token, $ip) {
 		$builder = $this->db->getQueryBuilder();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$lastAttempt = $builder->select('attempted_at')
 			->from($this->tableName)
 			->where($builder->expr()->eq('link_token', $builder->createNamedParameter($token)))

--- a/lib/Db/FailedLoginAttemptMapper.php
+++ b/lib/Db/FailedLoginAttemptMapper.php
@@ -66,6 +66,7 @@ class FailedLoginAttemptMapper extends Mapper {
 	 */
 	public function getFailedLoginCountForUidIpCombination($uid, $ip, $thresholdTime) {
 		$builder = $this->db->getQueryBuilder();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$attempts = $builder->selectAlias($builder->createFunction('COUNT(*)'), 'count')
 			->from($this->tableName)
 			->where($builder->expr()->gt('attempted_at', $builder->createNamedParameter($thresholdTime)))
@@ -83,6 +84,7 @@ class FailedLoginAttemptMapper extends Mapper {
 	 */
 	public function getLastFailedLoginAttemptTimeForUidIpCombination($uid, $ip) {
 		$builder = $this->db->getQueryBuilder();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$lastAttempt = $builder->select('attempted_at')
 			->from($this->tableName)
 			->where($builder->expr()->eq('uid', $builder->createNamedParameter($uid)))


### PR DESCRIPTION
`doctrine/dbal` was updated yesterday in core https://github.com/owncloud/core/pull/38647

Some methods have been deprecated, and `phan` reports those and fails the CI.

Suppress the deprecation warnings for now.

I raised issue #155 to actually adjust the code "some time".