### PR TITLE
[tests-only] Test against core master

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1663,7 +1663,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         "pull": "always",
         "commands": [
             "mkdir /tmp/testrunner",
-            "git clone -b acceptance-test-changes-waiting-2021-11 --depth=1 https://github.com/owncloud/core.git /tmp/testrunner",
+            "git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner",
             "rsync -aIX /tmp/testrunner %s" % dir["base"],
         ] + ([
             "cp -r %s/apps/%s %s/apps/" % (dir["testrunner"], ctx.repo.name, dir["server"]),


### PR DESCRIPTION
PR #166 accidentally started testing against core branch `acceptance-test-changes-waiting-2021-11` but actually that does not work, because there are core changes in that branch that are incompatible with the core tarballs.

Revert that change.