### PR TITLE
Drop PHP 7.3 unit testing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -49,18 +49,8 @@ config = {
     "phpunit": {
         "allDatabases": {
             "phpVersions": [
-                "7.3",
-            ],
-        },
-        "reducedDatabases": {
-            "phpVersions": [
                 DEFAULT_PHP_VERSION,
             ],
-            "databases": [
-                "sqlite",
-                "mariadb:10.2",
-            ],
-            "coverage": False,
         },
     },
     "acceptance": {


### PR DESCRIPTION
core master has dropped PHP 7.3 support in PR https://github.com/owncloud/core/pull/40394 - so do not try to run PHP unit tests with 7.3 any more.