### PR TITLE
Apply brute login policy on failed login

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -100,6 +100,10 @@ class Hooks {
 	 */
 	public function failedLoginCallback($event) {
 		$uid = $event->getArgument('user');
+		// apply policy to throw the login exception if needed.
+		// The failed login attempt won't be stored if the exception is thrown (same behavior with OC 10.11 and earlier)
+		$this->throttle->applyBruteForcePolicyForLogin($uid, $this->request->getRemoteAddress());
+
 		$attempt = new FailedLoginAttempt();
 		$attempt->setUid($uid);
 		$attempt->setIp($this->request->getRemoteAddress());

--- a/tests/acceptance/features/webUIBruteForceProtection/bruteforceprotection.feature
+++ b/tests/acceptance/features/webUIBruteForceProtection/bruteforceprotection.feature
@@ -9,6 +9,7 @@ Feature: brute force protection
     Given these users have been created without skeleton files:
       | username |
       | Alice    |
+      | Brian    |
     When the administrator sets the bruteforceprotection settings using the webUI to:
       | threshold-time | 60  |
       | fail-tolerance | 2   |
@@ -22,15 +23,15 @@ Feature: brute force protection
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 
-  Scenario: login blocked
+  Scenario: login is blocked with valid password
     When the user logs in with username "Alice" and invalid password "invalidpassword" using the webUI
     And the user logs in with username "Alice" and invalid password "invalidpassword" using the webUI
     And the blocked user "Alice" tries to login using the password "%regular%" from the webUI
     Then the user should be redirected to a webUI page with the title "ownCloud"
 
 
-  Scenario: login is not blocked with invalid password
-    When the user logs in with username "Alice" and invalid password "invalidpassword" using the webUI
-    And the user logs in with username "Alice" and invalid password "invalidpassword" using the webUI
-    And the user logs in with username "Alice" and invalid password "invalidpassword" using the webUI
-    Then the user should be redirected to the login page
+  Scenario: login is blocked with invalid password
+    When the user logs in with username "Brian" and invalid password "invalidpassword" using the webUI
+    And the user logs in with username "Brian" and invalid password "invalidpassword" using the webUI
+    And the blocked user "Brian" tries to login using the password "invalidpassword" from the webUI
+    Then the user should be redirected to a webUI page with the title "ownCloud"


### PR DESCRIPTION
Due to changes in OC 10.12 (not released yet), the behavior of the app has changed. This PR will bring back the old behavior.

Related to https://github.com/owncloud/brute_force_protection/issues/191

-----

OC versions 10.11 and earlier trigger a pre-login event and then a failed login event if needed. The brute login policy was applied only on the pre-login event, which happened even if the login failed afterwards.

With OC 10.12, the pre-login event happens after most of the checks have been done. This means that if the login fails, a failed login event will be triggered but not a pre-login event. This change in the order of the events causes problems with the app behavior.

In order to fix this issue, the brute login policy will also be applied when a login fails. Note that the failed login won't be registered if it happened during the ban period (no change in the behavior)

This change is expected to be backwards compatible.