### PR TITLE
Log of blocking a user

### DIFF
--- a/lib/Throttle.php
+++ b/lib/Throttle.php
@@ -95,7 +95,11 @@ class Throttle {
 		$thresholdTime = $lastAttempt - $this->config->getBruteForceProtectionTimeThreshold();
 		if ($this->loginAttemptMapper->getFailedLoginCountForUidIpCombination($uid, $ip, $thresholdTime) >=
 			$this->config->getBruteForceProtectionFailTolerance()) {
-			$this->logger->warning('User \''. $uid .'\' is blocked for'. $this->parseBanPeriodForHumans($banPeriod) .'. Too many failed login attempts', ['app' => 'brute_force_protection']);
+			$humanBanPeriod = $this->parseBanPeriodForHumans($banPeriod);
+			$this->logger->warning(
+				"User '{$uid}' is blocked for{$humanBanPeriod}. Too many failed login attempts",
+				['app' => 'brute_force_protection']
+			);
 			throw new LoginException(
 				$this->l->t(
 					"Too many failed login attempts. Try again in %s.",

--- a/lib/Throttle.php
+++ b/lib/Throttle.php
@@ -30,6 +30,7 @@ use OCA\BruteForceProtection\Db\FailedLoginAttemptMapper;
 use OCA\BruteForceProtection\Exceptions\LinkAuthException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
+use OCP\ILogger;
 
 /**
  * Class Throttle
@@ -49,6 +50,9 @@ class Throttle {
 	/** @var IL10N $l */
 	protected $l;
 
+	/** @var ILogger $logger */
+	private $logger;
+	
 	/** @var ITimeFactory $timeFactory */
 	protected $timeFactory;
 
@@ -64,12 +68,14 @@ class Throttle {
 		FailedLinkAccessMapper $linkAccessMapper,
 		BruteForceProtectionConfig $config,
 		IL10N $l,
+		ILogger $logger,
 		ITimeFactory $timeFactory
 	) {
 		$this->loginAttemptMapper = $loginAttemptMapper;
 		$this->linkAccessMapper = $linkAccessMapper;
 		$this->config = $config;
 		$this->l = $l;
+		$this->logger = $logger;
 		$this->timeFactory = $timeFactory;
 	}
 
@@ -88,6 +94,7 @@ class Throttle {
 		$thresholdTime = $lastAttempt - $this->config->getBruteForceProtectionTimeThreshold();
 		if ($this->loginAttemptMapper->getFailedLoginCountForUidIpCombination($uid, $ip, $thresholdTime) >=
 			$this->config->getBruteForceProtectionFailTolerance()) {
+			$this->logger->warning('User \''. $uid .'\' is blocked for '. $this->parseBanPeriodForHumans($banPeriod) .'. Too many failed login attempts', ['app' => 'brute_force_protection']);
 			throw new LoginException(
 				$this->l->t(
 					"Too many failed login attempts. Try again in %s.",

--- a/lib/Throttle.php
+++ b/lib/Throttle.php
@@ -95,7 +95,7 @@ class Throttle {
 		$thresholdTime = $lastAttempt - $this->config->getBruteForceProtectionTimeThreshold();
 		if ($this->loginAttemptMapper->getFailedLoginCountForUidIpCombination($uid, $ip, $thresholdTime) >=
 			$this->config->getBruteForceProtectionFailTolerance()) {
-			$this->logger->warning('User \''. $uid .'\' is blocked for '. $this->parseBanPeriodForHumans($banPeriod) .'. Too many failed login attempts', ['app' => 'brute_force_protection']);
+			$this->logger->warning('User \''. $uid .'\' is blocked for'. $this->parseBanPeriodForHumans($banPeriod) .'. Too many failed login attempts', ['app' => 'brute_force_protection']);
 			throw new LoginException(
 				$this->l->t(
 					"Too many failed login attempts. Try again in %s.",

--- a/lib/Throttle.php
+++ b/lib/Throttle.php
@@ -61,6 +61,7 @@ class Throttle {
 	 * @param FailedLinkAccessMapper $linkAccessMapper
 	 * @param BruteForceProtectionConfig $config
 	 * @param IL10N $l
+	 * @param ILogger $logger
 	 * @param ITimeFactory $timeFactory
 	 */
 	public function __construct(

--- a/tests/unit/ThrottleTest.php
+++ b/tests/unit/ThrottleTest.php
@@ -30,6 +30,7 @@ use OCA\BruteForceProtection\Throttle;
 use OCA\BruteForceProtection\BruteForceProtectionConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
+use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -49,6 +50,9 @@ class ThrottleTest extends TestCase {
 
 	/** @var MockObject | IL10N */
 	private $lMock;
+	
+	/** @var MockObject | ILogger */
+	private $loggerMock;
 
 	/** @var MockObject | ITimeFactory */
 	private $timeFactoryMock;
@@ -59,6 +63,7 @@ class ThrottleTest extends TestCase {
 		$this->loginAttemptMapper = $this->createMock(FailedLoginAttemptMapper::class);
 		$this->linkAccessMapper = $this->createMock(FailedLinkAccessMapper::class);
 		$this->lMock = $this->createMock(IL10N::class);
+		$this->loggerMock = $this->createMock(ILogger::class);
 		$this->timeFactoryMock = $this->createMock(ITimeFactory::class);
 		$this->configMock = $this->createMock(BruteForceProtectionConfig::class);
 
@@ -67,6 +72,7 @@ class ThrottleTest extends TestCase {
 			$this->linkAccessMapper,
 			$this->configMock,
 			$this->lMock,
+			$this->loggerMock,
 			$this->timeFactoryMock
 		);
 	}


### PR DESCRIPTION
Fix #200 

Please test and modify the log message if necessary.

The initial log message of a failed login is generated by: [https://github.com/owncloud/core/blob/master/lib/private/User/Manager.php#L272](https://github.com/owncloud/core/blob/master/lib/private/User/Manager.php#L272)