### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,100 @@
-# Brute Force Protection App
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/brute_force_protection/status.svg)](https://drone.owncloud.com/owncloud/brute_force_protection)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_brute_force_protection&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_brute_force_protection)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_brute_force_protection&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_brute_force_protection)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_brute_force_protection&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_brute_force_protection)
+# Brute Force Protection
 
-The Brute Force Protection App temporarily blocks logins to user accounts, from the originating IP address, after a configurable number of failed login attempts have taken place. The time frame of the ban and the number of unsuccessful login attempts during a time period are all configurable by ownCloud administrators.
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
+
+[![License](https://img.shields.io/badge/License-GPL--2.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
+
+The Brute Force Protection app temporarily blocks login attempts to user accounts from the originating IP address after a configurable number of failed login attempts. Administrators can configure the ban duration and the threshold of unsuccessful login attempts within a given time period. This helps protect ownCloud instances against brute-force password attacks.
+
+## Part of Classic (OC10)
+
+Brute Force Protection is a security app for [ownCloud Server (Classic)](https://github.com/owncloud/core). It is available on [Docker Hub as part of the ownCloud Server image](https://hub.docker.com/r/owncloud/server).
+
+## Getting Started
+
+1. Clone this repository into the `apps/` directory of your ownCloud Server installation
+2. Run `make` to build the app
+3. Enable the app: `occ app:enable brute_force_protection`
+4. Configure the protection parameters in the ownCloud admin panel
+
+## Documentation
+
+- [ownCloud Server documentation](https://doc.owncloud.com)
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/brute_force_protection)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [GPL-2.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: GPL-2.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: GPL-2.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,81 @@
+# AI Agent Guidelines for Brute Force Protection
+
+This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) working in this repository.
+
+## Repository Overview
+- **Product family:** Classic (OC10)
+- **Primary language(s):** PHP, JavaScript
+- **Build system:** Composer, Make
+- **Test framework:** PHPUnit
+- **CI system:** GitHub Actions
+
+## Architecture & Key Paths
+- `lib/` - PHP application logic
+- `appinfo/` - ownCloud app metadata and registration
+- `templates/` - Server-side templates
+- `js/` - Frontend JavaScript
+- `l10n/` - Translations
+- `img/` - App icons
+- `screenshots/` - App screenshots
+- `tests/` - PHPUnit test suite
+- `Makefile` - Build and test automation
+- `composer.json` - PHP dependencies
+- `phpcs.xml` - PHP_CodeSniffer configuration
+- `phpstan.neon` - PHPStan configuration
+- `phpunit.xml` - PHPUnit configuration
+
+## Development Conventions
+- **Branching:** master
+- **Commit messages:** DCO sign-off required (`git commit -s`)
+- **Code style:** PHP_CodeSniffer (phpcs.xml), ownCloud coding standard
+- **PR process:** Open a PR against master. All CI checks must pass.
+
+## Build & Test Commands
+```bash
+# Build
+make
+
+# Test
+make test-php-unit
+
+# Lint
+make test-php-style
+
+# Fix code style
+make test-php-style-fix
+
+# Static analysis
+make test-php-phpstan
+```
+
+## Important Constraints
+- All code contributions must be compatible with the **GPL-2.0** license
+- Do not introduce new **copyleft-licensed dependencies** (GPL, AGPL, LGPL, MPL) without explicit discussion in an issue first. This is especially important for repos migrating to Apache 2.0.
+- Do not introduce new dependencies without discussion in an issue first
+- This is a security-sensitive app - changes should be reviewed carefully
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+- Match existing code style
+- Do not refactor unrelated code in the same PR
+- Write tests for new functionality
+- Keep PRs focused and atomic
+- Security-related code requires extra scrutiny

--- a/agents.md
+++ b/agents.md
@@ -17,7 +17,7 @@ This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cu
 - `l10n/` - Translations
 - `img/` - App icons
 - `screenshots/` - App screenshots
-- `tests/` - PHPUnit test suite
+- `tests/` - PHPUnit and acceptance test suite
 - `Makefile` - Build and test automation
 - `composer.json` - PHP dependencies
 - `phpcs.xml` - PHP_CodeSniffer configuration
@@ -35,8 +35,15 @@ This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cu
 # Build
 make
 
-# Test
+# Test (PHPunit)
 make test-php-unit
+
+# Test (API acceptance)
+make test-acceptance-api
+
+# Test (WebUI acceptance)
+make test-acceptance-webui
+
 
 # Lint
 make test-php-style


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>