### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - xxxx-xx-xx
 
+
+## [1.4.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [1.4.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [1.3.0] - 2024-01-09
 
 - [#204](https://github.com/owncloud/brute_force_protection/pull/204) - Log of blocking a user
@@ -39,7 +50,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Initial release
 
-[Unreleased]: https://github.com/owncloud/brute_force_protection/compare/v1.3.0...master
+[Unreleased]: https://github.com/owncloud/brute_force_protection/compare/v1.4.1..master
+[1.4.1]: https://github.com/owncloud/brute_force_protection/compare/v1.4.0..v1.4.1
+[1.4.0]: https://github.com/owncloud/brute_force_protection/compare/v1.3.0..v1.4.0
 [1.3.0]: https://github.com/owncloud/brute_force_protection/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/owncloud/brute_force_protection/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/owncloud/brute_force_protection/compare/v1.0.1...v1.1.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ See the [2-Factor Authentication](https://marketplace.owncloud.com/apps/twofacto
 	<summary>Prevent attackers from guessing user passwords</summary>
 	<licence>GPLv2</licence>
 	<author>Semih Serhat Karakaya</author>
-	<version>1.4.0</version>
+	<version>1.4.1</version>
 	<namespace>BruteForceProtection</namespace>
 	<use-migrations>true</use-migrations>
 	<dependencies>


### PR DESCRIPTION
Patch-level version bump (1.4.0 -> 1.4.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.